### PR TITLE
Tarball

### DIFF
--- a/core/reader.py
+++ b/core/reader.py
@@ -165,7 +165,8 @@ class MainWindowReader(QtGui.QMainWindow, Ui_MainWindowReader):
         filename = QtGui.QFileDialog.getOpenFileName(
             parent=self,
             caption='Select a file to open',
-            filter='Archive files (*.bz2 *.gz *.tar *.tgz);;Text files (*.txt);;All files (*.*)'
+            filter='Archive files (*.bz2 *.gz *.tar *.tgz);;Text files (*.txt);;All files (*.*)',
+            selectedFilter='Text files (*.txt)'
         )
         if not filename.isNull():
             self.openFile(filename)


### PR DESCRIPTION
Have made some changes to make it possible to open a file in a tarball (*.tar, *.gz, *.bz2, *.tgz).

If the tarball contains a single file (excluding directories), that file is opened. If there are many files, a dialog to select one of them is shown.

Known issues: 
- Does not remember which file in the tarball that was opened last time.
- Must reopen the tarball to open another file in it.
- If the tarball is empty, a ReadError will be raised. (http://bugs.python.org/issue6123)
