### PR TITLE
Menu item for open another file in same archive

### DIFF
--- a/core/reader.py
+++ b/core/reader.py
@@ -352,6 +352,7 @@ class MainWindowReader(QtGui.QMainWindow, Ui_MainWindowReader):
         self.setWindowTitle(u'Yomichan - {0} ({1})'.format(os.path.split(filename)[1], encoding))
         
     def openFileByExtension(self, filename):
+        self.clearArchiveFiles()
         if tarfile.is_tarfile(filename):
             # opening an empty tar file raises ReadError
             with tarfile.open(filename, 'r:*') as tp:
@@ -530,8 +531,6 @@ class MainWindowReader(QtGui.QMainWindow, Ui_MainWindowReader):
         
     
     def updateArchiveFiles(self, filename, names):
-        self.clearArchiveFiles()
-        
         self.menuOpenArchive.setEnabled(True)
         for name in self.formatQStringList(names):
             (index, ok) = self.getItemIndex(name)

--- a/core/reader_ui.py
+++ b/core/reader_ui.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'dev/reader.ui'
 #
-# Created: Fri Oct  7 08:55:15 2011
+# Created: Mon Nov 14 19:35:11 2011
 #      by: PyQt4 UI code generator 4.8.5
 #
 # WARNING! All changes made in this file will be lost!
@@ -40,9 +40,9 @@ class Ui_MainWindowReader(object):
         self.menuFile.setTitle(QtGui.QApplication.translate("MainWindowReader", "&File", None, QtGui.QApplication.UnicodeUTF8))
         self.menuFile.setObjectName(_fromUtf8("menuFile"))
         self.menuOpenArchive = QtGui.QMenu(self.menuFile)
+        self.menuOpenArchive.setEnabled(False)
         self.menuOpenArchive.setTitle(QtGui.QApplication.translate("MainWindowReader", "Open from &archive", None, QtGui.QApplication.UnicodeUTF8))
         self.menuOpenArchive.setObjectName(_fromUtf8("menuOpenArchive"))
-        self.menuOpenArchive.setEnabled(False)
         self.menuOpenRecent = QtGui.QMenu(self.menuFile)
         self.menuOpenRecent.setTitle(QtGui.QApplication.translate("MainWindowReader", "Open &recent", None, QtGui.QApplication.UnicodeUTF8))
         self.menuOpenRecent.setObjectName(_fromUtf8("menuOpenRecent"))

--- a/dev/reader.ui
+++ b/dev/reader.ui
@@ -47,12 +47,21 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
+    <widget class="QMenu" name="menuOpenArchive">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="title">
+      <string>Open from &amp;archive</string>
+     </property>
+    </widget>
     <widget class="QMenu" name="menuOpenRecent">
      <property name="title">
       <string>Open &amp;recent</string>
      </property>
     </widget>
     <addaction name="actionOpen"/>
+    <addaction name="menuOpenArchive" />
     <addaction name="menuOpenRecent"/>
     <addaction name="separator"/>
     <addaction name="actionQuit"/>


### PR DESCRIPTION
Added a menu item "Open in archive" that is active when the user has opened a file in an archive. The menu item lists all file in the same archive and the user can click on a file name to open that file instead.

As a side-effect, the program also remembers which file in an archive that was opened last time.
