### PR TITLE
Fixed Anki startup error caused by an import error in reader.py

### DIFF
--- a/yomi_base/reader.py
+++ b/yomi_base/reader.py
@@ -20,7 +20,6 @@ from PyQt4 import QtGui, QtCore
 import about
 import constants
 import gen.reader_ui
-import japanese.util
 import os
 import preferences
 import reader_util


### PR DESCRIPTION
reader.py still had an import statement for japanese/util.py despite its removal previously. As a result, the error below displayed on startup of Anki and yomichan was inaccessible

Removing the import statement for japanese/util fixes the issue

Error that occured:
Traceback (most recent call last):
  File "aqt\addons.py", line 41, in loadAddons
  File "C:\Users\PC\Documents\Anki\addons\yomichan.py", line 24, in <module>
    from yomi_base.reader import MainWindowReader
  File "C:\Users\PC\Documents\Anki\addons\yomi_base\reader.py", line 23, in <module>
    import japanese.util
ImportError: No module named util
